### PR TITLE
added homebrew-specific header path fix to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ $ apt-get install libgeos-dev
 $ brew install geos
 ```
 
+Note that Xcode messes with the default gcc search/include directories.
+Run these in your terminal or put them in `~/.profile` to fix `./geos.h:1:10: fatal error: 'geos_c.h' file not found`
+
+````bash
+export C_INCLUDE_PATH=/usr/local/include
+export LIBRARY_PATH=/usr/local/lib
+export LD_LIBRARY_PATH=/usr/local/lib
+````
+
 #### From source (all OSes)
 
 ```bash


### PR DESCRIPTION
I went to use this in a mac with homebrew and got include and linker errors on compile. I traced it down to xcode messing with the default include and linker paths and removing the default gcc behavior of looking in `/usr/lib/...` (which is where homebrew puts the headers and libs). Just wanted to update the docs and save others the work I went through.

Do you want me to submit another pull request to gh-pages with the same verbiage?
