### PR TITLE
Correct import path

### DIFF
--- a/geos/examples.go
+++ b/geos/examples.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"os"
 
-	"code.google.com/p/draw2d/draw2d"
+	"github.com/llgcode/draw2d"
 
 	"github.com/paulsmith/gogeos/geos"
 )


### PR DESCRIPTION
`dep init` chokes on this path, so better to update it to the
new home for this repository on github.