### PR TITLE
Update draw2d to be used via Github

### DIFF
--- a/geos/examples.go
+++ b/geos/examples.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"os"
 
-	"code.google.com/p/draw2d/draw2d"
+	"github.com/llgcode/draw2d"
 
 	"github.com/paulsmith/gogeos/geos"
 )


### PR DESCRIPTION
`dep ensure` is currently failing on anything that depends on this package `gogeos` because of this error:

```
init failed: unable to solve the dependency graph: Solving failure: No versions of github.com/paulsmith/gogeos met constraints:
	v0.1.2: unable to deduce repository and source type for "code.google.com/p/draw2d/draw2d": unable to read metadata: go-import metadata not found
	v0.1.1: unable to deduce repository and source type for "code.google.com/p/draw2d/draw2d": unable to read metadata: go-import metadata not found
	v0.1.0: unable to deduce repository and source type for "code.google.com/p/draw2d/draw2d": unable to read metadata: go-import metadata not found
	master: unable to deduce repository and source type for "code.google.com/p/draw2d/draw2d": unable to read metadata: go-import metadata not found
```